### PR TITLE
Specified the encoding for the ReadStream.

### DIFF
--- a/level-ttl.js
+++ b/level-ttl.js
@@ -8,9 +8,14 @@ var startTtl = function (db, checkFrequency) {
       db._ttl.intervalId = setInterval(function () {
         var batch    = []
           , subBatch = []
+          , query = {
+                keyEncoding: 'utf8'
+              , valueEncoding: 'utf8'
+              , end: String(Date.now())
+            }
 
         db._ttl._checkInProgress = true
-        db._ttl.sub.createReadStream({ end: String(Date.now()) })
+        db._ttl.sub.createReadStream(query)
           .on('data', function (data) {
             subBatch.push({ type: 'del', key: data.value })
             subBatch.push({ type: 'del', key: data.key })


### PR DESCRIPTION
I have added the encodings to the `ReadStream` used expiring the entries. 

I am not really sure where to put the tests  for it.
Should I modify the `ltest` method to accept some options for `levelup`?

I have also seen that this depends on old versions of LevelUp and SubLevel.
