### PR TITLE
unref ttl interval to not hang

### DIFF
--- a/level-ttl.js
+++ b/level-ttl.js
@@ -50,6 +50,8 @@ var startTtl = function (db, checkFrequency) {
             }
           })
       }, checkFrequency)
+      if (db._ttl.intervalId.unref)
+        db._ttl.intervalId.unref()
     }
 
   , stopTtl = function (db, callback) {


### PR DESCRIPTION
This PR calls `unref` on the interval object. This result of this that the process shouldn't hang even if `stop` isn't called. It is guarded since `unref` is a newish addition to node. 
