### PR TITLE
emit event 'ttl' when the function ttl is executed.

### DIFF
--- a/level-ttl.js
+++ b/level-ttl.js
@@ -126,6 +126,7 @@ function ttloff (db, keys, callback) {
       , { keyEncoding: 'utf8', valueEncoding: 'utf8' }
       , function (err, exp) {
           if (!err && exp > 0) {
+            db.emit('ttl', key);
             batch.push({ type: 'del', key: key })
             batch.push({ type: 'del', key: exp + '!' + key })
           }


### PR DESCRIPTION
Well, 
Sometimes is very useful catch when the ttl is running for execute a job at this time.

I'm not sure if that is the better moment to emit the event, but the feature is really useful. 
