### PR TITLE
add .sub option for passing in your own sub db

### DIFF
--- a/level-ttl.js
+++ b/level-ttl.js
@@ -234,7 +234,7 @@ function setup (db, options) {
     , del   : db.del.bind(db)
     , batch : db.batch.bind(db)
     , close : db.close.bind(db)
-    , sub   : spaces(db, options.namespace)
+    , sub   : options.sub || spaces(db, options.namespace)
   }
 
   db[options.methodPrefix + 'put']   = put.bind(null, db)


### PR DESCRIPTION
this is intended to address https://github.com/rvagg/node-level-ttl/issues/15

the idea is simply that you can pass your own levelup-ish instance in

I tested this with level-session and it fixes the issues with level-sublevel v6

another idea for the option name I had was `ttldb` rather than `sub`. LMK if you like that more and I can update it
