### PR TITLE
Adds support for alternate encodings for ttl records (e.g. bytewise)

### DIFF
--- a/encoding.js
+++ b/encoding.js
@@ -1,0 +1,28 @@
+exports.create = function createEncoding (options) {
+  options || (options = {})
+
+  if (options.ttlEncoding)
+    return options.ttlEncoding
+
+  const PATH_SEP    = options.separator
+      , INITIAL_SEP = options.sub ? '' : PATH_SEP
+
+  function encodeElement(e) {
+    // transform dates to timestamp strings
+    return String(e instanceof Date ? +e : e)
+  }
+
+  return {
+      buffer : false
+    , encode : function (e) {
+        // TODO: reexamine this with respect to level-sublevel@6's native codecs
+        if (Array.isArray(e))
+          return new Buffer(INITIAL_SEP + e.map(encodeElement).join(PATH_SEP))
+        return new Buffer(encodeElement(e))
+      }
+    , decode : function (e) {
+        // TODO: detect and parse ttl records
+        return e.toString('utf8')
+      }
+  }
+}

--- a/level-ttl.js
+++ b/level-ttl.js
@@ -1,40 +1,33 @@
 const after = require('after')
     , xtend = require('xtend')
 
-    , DEFAULT_FREQUENCY = 10000
-    , QUERY_SEPARATOR   = 'x!'
-
-function expirationKey (db, exp, key) {
-  var separator = db._ttl.options.separator
-  return queryStart(db) + exp + separator + key
+function prefixKey (db, key) {
+  return db._ttl.encoding.encode(db._ttl._prefixNs.concat(key))
 }
 
-function queryStart (db) {
-  return prefix(db) + QUERY_SEPARATOR
+function expiryKey (db, exp, key) {
+  return db._ttl.encoding.encode(db._ttl._expiryNs.concat(exp, key))
 }
 
-function prefix (db) {
-  if (db._ttl.sub)
-    return ''
-
-  var separator = db._ttl.options.separator
-  var namespace = db._ttl.options.namespace
-  return separator + namespace + separator
+function buildQuery (db) {
+  const encode    = db._ttl.encoding.encode
+      , _expiryNs = db._ttl._expiryNs
+  return {
+      keyEncoding   : 'binary'
+    , valueEncoding : 'binary'
+    , gte           : encode(_expiryNs)
+    , lte           : encode(_expiryNs.concat(Date.now()))
+  }
 }
 
 function startTtl (db, checkFrequency) {
   db._ttl.intervalId = setInterval(function () {
-    var batch     = []
-      , subBatch  = []
-      , start     = queryStart(db)
-      , sub       = db._ttl.sub
-      , query     = {
-            keyEncoding: 'utf8'
-          , valueEncoding: 'utf8'
-          , start: start
-          , end: start + String(Date.now()) + '~'
-        }
-      , createReadStream
+    const batch    = []
+        , subBatch = []
+        , sub      = db._ttl.sub
+        , query    = buildQuery(db)
+        , decode   = db._ttl.encoding.decode
+    var createReadStream
 
     db._ttl._checkInProgress = true
 
@@ -45,12 +38,13 @@ function startTtl (db, checkFrequency) {
 
     createReadStream(query)
       .on('data', function (data) {
-        // expirationKey that matches this query
-        subBatch.push({ type: 'del', key: data.key })
         // the value is the key!
-        subBatch.push({ type: 'del', key: prefix(db) + data.value })
+        const key = decode(data.value)
+        // expiryKey that matches this query
+        subBatch.push({ type: 'del', key: data.key })
+        subBatch.push({ type: 'del', key: prefixKey(db, key) })
         // the actual data that should expire now!
-        batch.push({ type: 'del', key: data.value })
+        batch.push({ type: 'del', key: key })
       })
       .on('error', db.emit.bind(db, 'error'))
       .on('end', function () {
@@ -60,7 +54,7 @@ function startTtl (db, checkFrequency) {
         if (sub) {
           sub.batch(
               subBatch
-            , { keyEncoding: 'utf8' }
+            , { keyEncoding: 'binary' }
             , function (err) {
                 if (err)
                   db.emit('error', err)
@@ -69,7 +63,7 @@ function startTtl (db, checkFrequency) {
 
           db._ttl.batch(
               batch
-            , { keyEncoding: 'utf8' }
+            , { keyEncoding: 'binary' }
             , function (err) {
                 if (err)
                   db.emit('error', err)
@@ -79,7 +73,7 @@ function startTtl (db, checkFrequency) {
         else {
           db._ttl.batch(
               subBatch.concat(batch)
-            , { keyEncoding: 'utf8' }
+            , { keyEncoding: 'binary' }
             , function (err) {
                 if (err)
                   db.emit('error', err)
@@ -110,20 +104,17 @@ function stopTtl (db, callback) {
 }
 
 function ttlon (db, keys, ttl, callback) {
-  var exp     = String(Date.now() + ttl)
-    , sub     = db._ttl.sub
+  // TODO: proper dates
+  const exp   = Date.now() + ttl
     , batch   = []
+    , sub     = db._ttl.sub
     , batchFn = (sub ? sub.batch.bind(sub) : db._ttl.batch)
-
-  if (!Array.isArray(keys))
-    keys = [ keys ]
+    , encode  = db._ttl.encoding.encode
 
   ttloff(db, keys, function () {
     keys.forEach(function (key) {
-      if (typeof key != 'string')
-        key = key.toString()
-      batch.push({ type: 'put', key: expirationKey(db, exp, key), value: key })
-      batch.push({ type: 'put', key: prefix(db) + key, value: exp })
+      batch.push({ type: 'put', key: expiryKey(db, exp, key), value: encode(key) })
+      batch.push({ type: 'put', key: prefixKey(db, key), value: encode(exp) })
     })
 
     if (!batch.length)
@@ -131,7 +122,7 @@ function ttlon (db, keys, ttl, callback) {
 
     batchFn(
         batch
-      , { keyEncoding: 'utf8', valueEncoding: 'utf8' }
+      , { keyEncoding: 'binary', valueEncoding: 'binary' }
       , function (err) {
           if (err)
             db.emit('error', err)
@@ -142,42 +133,38 @@ function ttlon (db, keys, ttl, callback) {
 }
 
 function ttloff (db, keys, callback) {
-  if (!Array.isArray(keys))
-    keys = [ keys ]
+  const batch   = []
+      , sub     = db._ttl.sub
+      , getFn   = (sub ? sub.get.bind(sub) : db.get.bind(db))
+      , batchFn = (sub ? sub.batch.bind(sub) : db._ttl.batch)
+      , decode  = db._ttl.encoding.decode
+      , done    = after(keys.length, function (err) {
+          if (err)
+            db.emit('error', err)
 
-  var batch   = []
-    , sub     = db._ttl.sub
-    , getFn   = (sub ? sub.get.bind(sub) : db.get.bind(db))
-    , batchFn = (sub ? sub.batch.bind(sub) : db._ttl.batch)
-    , done    = after(keys.length, function (err) {
-        if (err)
-          db.emit('error', err)
+          if (!batch.length)
+            return callback && callback()
 
-        if (!batch.length)
-          return callback && callback()
-
-        batchFn(
-            batch
-          , { keyEncoding: 'utf8', valueEncoding: 'utf8' }
-          , function (err) {
-              if (err)
-                db.emit('error', err)
-              callback && callback()
-            }
-        )
-      })
+          batchFn(
+              batch
+            , { keyEncoding: 'binary', valueEncoding: 'binary' }
+            , function (err) {
+                if (err)
+                  db.emit('error', err)
+                callback && callback()
+              }
+          )
+        })
 
   keys.forEach(function (key) {
-    if (typeof key != 'string')
-      key = key.toString()
-
+    const prefixedKey = prefixKey(db, key)
     getFn(
-        prefix(db) + key
-      , { keyEncoding: 'utf8', valueEncoding: 'utf8' }
+        prefixedKey
+      , { keyEncoding: 'binary', valueEncoding: 'binary' }
       , function (err, exp) {
-          if (!err && exp > 0) {
-            batch.push({ type: 'del', key: expirationKey(db, exp, key) })
-            batch.push({ type: 'del', key: prefix(db) + key })
+          if (!err && exp) {
+            batch.push({ type: 'del', key: expiryKey(db, decode(exp), key) })
+            batch.push({ type: 'del', key: prefixedKey })
           }
           done(err && err.name != 'NotFoundError' && err)
         }
@@ -191,7 +178,7 @@ function put (db, key, value, options, callback) {
     options = {}
   }
 
-  options = options || {}
+  options || (options = {})
 
   if (db._ttl.options.defaultTTL > 0 && !options.ttl && options.ttl != 0) {
     options.ttl = db._ttl.options.defaultTTL
@@ -200,30 +187,27 @@ function put (db, key, value, options, callback) {
   var done
     , _callback = callback
 
-  if (options.ttl > 0
-      && key !== null && key !== undefined
-      && value !== null && value !== undefined) {
-
+  if (options.ttl > 0 && key != null && value != null) {
     done = after(2, _callback || function () {})
     callback = done
-    ttlon(db, key, options.ttl, done)
+    ttlon(db, [ key ], options.ttl, done)
   }
 
   db._ttl.put.call(db, key, value, options, callback)
 }
 
-function ttl (db, key, _ttl, callback) {
-  if (_ttl > 0 && key !== null && key !== undefined)
-    ttlon(db, key, _ttl, callback)
+function setTtl (db, key, ttl, callback) {
+  if (ttl > 0 && key != null)
+    ttlon(db, [ key ], ttl, callback)
 }
 
 function del (db, key, options, callback) {
   var done
     , _callback = callback
-  if (key !== null && key !== undefined) {
+  if (key != null) {
     done = after(2, _callback || function () {})
     callback = done
-    ttloff(db, key, done)
+    ttloff(db, [ key ], done)
   }
 
   db._ttl.del.call(db, key, options, callback)
@@ -235,7 +219,7 @@ function batch (db, arr, options, callback) {
     options = {}
   }
 
-  options = options || {}
+  options || (options = {})
 
   if (db._ttl.options.defaultTTL > 0 && !options.ttl && options.ttl != 0) {
     options.ttl = db._ttl.options.defaultTTL
@@ -253,10 +237,10 @@ function batch (db, arr, options, callback) {
     on  = []
     off = []
     arr.forEach(function (entry) {
-      if (!entry || entry.key === null || entry.key === undefined)
+      if (!entry || entry.key == null)
         return
 
-      if (entry.type == 'put' && entry.value !== null && entry.value !== undefined)
+      if (entry.type == 'put' && entry.value != null)
         on.push(entry.key)
       if (entry.type == 'del')
         off.push(entry.key)
@@ -283,33 +267,62 @@ function close (db, callback) {
   })
 }
 
+function legacyEncoding (options) {
+  const SEP = options.separator
+      , INITIAL_SEP = options.sub ? '' : SEP
+      , DATE_RE = /\d{13}/
+
+  return {
+      type   : 'legacy-ttl'
+    , buffer : false
+    , encode : function (e) {
+      if (Array.isArray(e)) {
+        // TODO: level-sublevel@6's native codec support could improve this
+        e = INITIAL_SEP + e.map(String).join(SEP)
+      }
+
+      return new Buffer(String(e))
+    }
+    , decode : function (e) {
+      // TODO: detect and parse ttl records
+      return e.toString('utf8')
+    }
+  }
+}
+
 function setup (db, options) {
   if (db._ttl)
     return
 
-  options = options || {}
+  options || (options = {})
 
   options = xtend({
-      methodPrefix   : ''
-    , namespace      : 'ttl'
-    , separator      : '!'
-    , checkFrequency : DEFAULT_FREQUENCY
-    , defaultTTL     : 0
+      methodPrefix    : ''
+    , namespace       : options.sub ? '' : 'ttl'
+    , expiryNamespace : 'x'
+    , separator       : '!'
+    , checkFrequency  : 10000
+    , defaultTTL      : 0
   }, options)
 
+  const _prefixNs = options.namespace ? [ options.namespace ] : []
+
   db._ttl = {
-      put     : db.put.bind(db)
-    , del     : db.del.bind(db)
-    , batch   : db.batch.bind(db)
-    , close   : db.close.bind(db)
-    , sub     : options.sub
-    , options : options
+      put       : db.put.bind(db)
+    , del       : db.del.bind(db)
+    , batch     : db.batch.bind(db)
+    , close     : db.close.bind(db)
+    , sub       : options.sub
+    , options   : options
+    , encoding  : options.ttlEncoding || legacyEncoding(options)
+    , _prefixNs : _prefixNs
+    , _expiryNs : _prefixNs.concat(options.expiryNamespace)
   }
 
   db[options.methodPrefix + 'put']   = put.bind(null, db)
   db[options.methodPrefix + 'del']   = del.bind(null, db)
   db[options.methodPrefix + 'batch'] = batch.bind(null, db)
-  db[options.methodPrefix + 'ttl']   = ttl.bind(null, db)
+  db[options.methodPrefix + 'ttl']   = setTtl.bind(null, db)
   db[options.methodPrefix + 'stop']  = stopTtl.bind(null, db)
   // we must intercept close()
   db.close                           = close.bind(null, db)

--- a/level-ttl.js
+++ b/level-ttl.js
@@ -1,5 +1,5 @@
-const after = require('after')
-    , xtend = require('xtend')
+const after    = require('after')
+    , xtend    = require('xtend')
     , encoding = require('./encoding')
 
 function prefixKey (db, key) {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "ltest": "2.0.0",
     "slump": "^2.0.0",
     "tape": ">=2.14.0 <2.15.0-0",
-    "bytewise": ">=0.7"
+    "bytewise": ">=0.8"
   },
   "scripts": {
     "test": "tape test.js | faucet"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "level-sublevel": "^6.4.6",
     "ltest": "2.0.0",
     "slump": "^2.0.0",
-    "tape": ">=2.14.0 <2.15.0-0"
+    "tape": ">=2.14.0 <2.15.0-0",
+    "bytewise": ">=0.7"
   },
   "scripts": {
     "test": "tape test.js | faucet"

--- a/test.js
+++ b/test.js
@@ -327,7 +327,7 @@ test('prolong entry life with additional put', function (t, db, createReadStream
   var retest = function (delay, cb) {
         setTimeout(function () {
           db.put('bar', 'barvalue', { ttl: 250 })
-          verifyIn(80, createReadStream, t, function (arr) {
+          verifyIn(50, createReadStream, t, function (arr) {
             contains(t, arr, 'foo', 'foovalue')
             contains(t, arr, 'bar', 'barvalue')
             contains(t, arr, /!ttl!x!\d{13}!bar/, 'bar')
@@ -348,7 +348,7 @@ test('prolong entry life with additional put (custom ttlEncoding)', function (t,
   var retest = function (delay, cb) {
         setTimeout(function () {
           db.put('bar', 'barvalue', { ttl: 250 })
-          verifyIn(80, createReadStream, t, function (arr) {
+          verifyIn(50, createReadStream, t, function (arr) {
             contains(t, arr, new Buffer('foo'), new Buffer('foovalue'))
             contains(t, arr, new Buffer('bar'), new Buffer('barvalue'))
             contains(t, arr, bwRange([ 'ttl', 'x' ]), bwEncode('bar'))
@@ -699,10 +699,10 @@ ltest('data and level-sublevel ttl meta data separation', function (t, db, creat
 })
 
 ltest('data and level-sublevel ttl meta data separation (custom ttlEncoding)', function (t, db, createReadStream) {
-  var subDb  = sublevel(db)
-    , meta   = subDb.sublevel('meta')
-    , ttldb  = ttl(db, { sub: meta, ttlEncoding: bytewise })
-    , batch  = randomPutBatch(5)
+  var subDb = sublevel(db)
+    , meta  = subDb.sublevel('meta')
+    , ttldb = ttl(db, { sub: meta, ttlEncoding: bytewise })
+    , batch = randomPutBatch(5)
 
   ttldb.batch(batch, { ttl: 10000 }, function (err) {
     t.ok(!err, 'no error')


### PR DESCRIPTION
I tried to be as unobtrusive as possible but I know this is a pretty massive commit. FWIW it should be completely backward-compatible.

Let me know if there's anything you'd like to see changed to get this merged.